### PR TITLE
fix: resolve DYNAMIC_SERVER_USAGE in statically rendered routes

### DIFF
--- a/src/app/[lang]/about/[[...slug]]/__tests__/not-found.test.tsx
+++ b/src/app/[lang]/about/[[...slug]]/__tests__/not-found.test.tsx
@@ -1,14 +1,6 @@
 jest.mock("next/navigation", () => ({
   ...jest.requireActual("next/navigation"),
-  notFound: jest.fn(),
-}));
-
-jest.mock("../../../../../lib/locale-from-headers", () => ({
-  getLocaleFromHeaders: jest.fn(),
-}));
-
-jest.mock("../../../../../lib/data/locales", () => ({
-  getAvailableAboutLocales: jest.fn(),
+  useParams: jest.fn(),
 }));
 
 jest.mock("../../../../../components/ui/empty", () => ({
@@ -26,106 +18,52 @@ jest.mock("../../../../../components/ui/empty", () => ({
 
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { useParams } from "next/navigation";
 import NotFound from "../not-found";
-import { getLocaleFromHeaders } from "../../../../../lib/locale-from-headers";
-import { getAvailableAboutLocales } from "../../../../../lib/data/locales";
 
-const mockGetLocale = getLocaleFromHeaders as jest.Mock;
-const mockGetLocales = getAvailableAboutLocales as jest.Mock;
+const mockUseParams = useParams as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockUseParams.mockReturnValue({ lang: "zh-TW" });
 });
 
 describe("About NotFound", () => {
-  it("renders zh-TW title when locale is zh-TW", async () => {
-    mockGetLocale.mockResolvedValue("zh-TW");
-    mockGetLocales.mockResolvedValue(["zh-TW", "en"]);
-
-    render(await NotFound());
-
+  it("renders zh-TW title when locale is zh-TW", () => {
+    mockUseParams.mockReturnValue({ lang: "zh-TW" });
+    render(<NotFound />);
     expect(screen.getByText("找不到關於頁面")).toBeInTheDocument();
   });
 
-  it("renders en title when locale is en", async () => {
-    mockGetLocale.mockResolvedValue("en");
-    mockGetLocales.mockResolvedValue(["en", "zh-TW"]);
-
-    render(await NotFound());
-
+  it("renders en title when locale is en", () => {
+    mockUseParams.mockReturnValue({ lang: "en" });
+    render(<NotFound />);
     expect(screen.getByText("About page not found")).toBeInTheDocument();
   });
 
-  it("renders ja title when locale is ja", async () => {
-    mockGetLocale.mockResolvedValue("ja");
-    mockGetLocales.mockResolvedValue(["ja"]);
-
-    render(await NotFound());
-
+  it("renders ja title when locale is ja", () => {
+    mockUseParams.mockReturnValue({ lang: "ja" });
+    render(<NotFound />);
     expect(screen.getByText("Aboutページが見つかりません")).toBeInTheDocument();
   });
 
-  it("shows locale buttons only for other available locales", async () => {
-    mockGetLocale.mockResolvedValue("en");
-    mockGetLocales.mockResolvedValue(["zh-TW", "en"]);
-
-    render(await NotFound());
-
-    expect(screen.getByText("繁體中文")).toBeInTheDocument();
-    expect(screen.queryByText("English")).not.toBeInTheDocument();
-  });
-
-  it("renders return-to-home link with correct href", async () => {
-    mockGetLocale.mockResolvedValue("en");
-    mockGetLocales.mockResolvedValue([]);
-
-    render(await NotFound());
-
+  it("renders return-to-home link with correct href for en", () => {
+    mockUseParams.mockReturnValue({ lang: "en" });
+    render(<NotFound />);
     const link = screen.getByText("Back to Home");
     expect(link.closest("a")).toHaveAttribute("href", "/en");
   });
 
-  it("shows human-readable locale names, not raw locale codes", async () => {
-    mockGetLocale.mockResolvedValue("en");
-    mockGetLocales.mockResolvedValue(["zh-TW", "en", "ja"]);
-
-    render(await NotFound());
-
-    expect(screen.getByText("繁體中文")).toBeInTheDocument();
-    expect(screen.getByText("日本語")).toBeInTheDocument();
-    expect(screen.queryByText("zh-TW")).not.toBeInTheDocument();
-    expect(screen.queryByText("ja")).not.toBeInTheDocument();
+  it("renders return-to-home link with correct href for zh-TW", () => {
+    mockUseParams.mockReturnValue({ lang: "zh-TW" });
+    render(<NotFound />);
+    const link = screen.getByText("返回首頁");
+    expect(link.closest("a")).toHaveAttribute("href", "/zh-TW");
   });
 
-  it("shows switcherLabel when other locales are available", async () => {
-    mockGetLocale.mockResolvedValue("en");
-    mockGetLocales.mockResolvedValue(["zh-TW", "en"]);
-
-    render(await NotFound());
-
-    expect(
-      screen.getByText("This content is also available in:")
-    ).toBeInTheDocument();
-  });
-
-  it("does NOT show switcherLabel when no other locales are available", async () => {
-    mockGetLocale.mockResolvedValue("en");
-    mockGetLocales.mockResolvedValue(["en"]);
-
-    render(await NotFound());
-
-    expect(
-      screen.queryByText("This content is also available in:")
-    ).not.toBeInTheDocument();
-  });
-
-  it("still renders without crashing when getAvailableAboutLocales throws", async () => {
-    mockGetLocale.mockResolvedValue("zh-TW");
-    mockGetLocales.mockRejectedValue(new Error("Sanity error"));
-
-    expect(async () => render(await NotFound())).not.toThrow();
-
-    render(await NotFound());
-    expect(screen.getAllByText("找不到關於頁面")[0]).toBeInTheDocument();
+  it("falls back to zh-TW when lang param is missing", () => {
+    mockUseParams.mockReturnValue({});
+    render(<NotFound />);
+    expect(screen.getByText("找不到關於頁面")).toBeInTheDocument();
   });
 });

--- a/src/app/[lang]/about/[[...slug]]/not-found.tsx
+++ b/src/app/[lang]/about/[[...slug]]/not-found.tsx
@@ -1,6 +1,7 @@
+"use client";
+
 import Link from "next/link";
-import { getLocaleFromHeaders } from "@/lib/locale-from-headers";
-import { getAvailableAboutLocales } from "@/lib/data/locales";
+import { useParams } from "next/navigation";
 import {
   Empty,
   EmptyHeader,
@@ -8,45 +9,16 @@ import {
   EmptyContent,
 } from "@/components/ui/empty";
 
-const LOCALE_NAMES: Record<string, string> = {
-  "zh-TW": "繁體中文",
-  en: "English",
-  ja: "日本語",
+const labels: Record<string, { title: string; back: string }> = {
+  "zh-TW": { title: "找不到關於頁面", back: "返回首頁" },
+  en: { title: "About page not found", back: "Back to Home" },
+  ja: { title: "Aboutページが見つかりません", back: "ホームに戻る" },
 };
 
-const labels: Record<
-  string,
-  { title: string; back: string; switcherLabel: string }
-> = {
-  "zh-TW": {
-    title: "找不到關於頁面",
-    back: "返回首頁",
-    switcherLabel: "此內容也提供以下語言版本：",
-  },
-  en: {
-    title: "About page not found",
-    back: "Back to Home",
-    switcherLabel: "This content is also available in:",
-  },
-  ja: {
-    title: "Aboutページが見つかりません",
-    back: "ホームに戻る",
-    switcherLabel: "このコンテンツは以下の言語でもご覧いただけます：",
-  },
-};
-
-export default async function NotFound() {
-  const locale = await getLocaleFromHeaders();
-
-  let availableLocales: string[] = [];
-  try {
-    availableLocales = await getAvailableAboutLocales();
-  } catch {
-    availableLocales = [];
-  }
-
-  const otherLocales = availableLocales.filter((l) => l !== locale);
-  const { title, back, switcherLabel } = labels[locale] ?? labels["zh-TW"];
+export default function NotFound() {
+  const params = useParams();
+  const locale = (params?.lang as string) ?? "zh-TW";
+  const { title, back } = labels[locale] ?? labels["zh-TW"];
 
   return (
     <Empty>
@@ -54,16 +26,6 @@ export default async function NotFound() {
         <EmptyTitle>{title}</EmptyTitle>
       </EmptyHeader>
       <EmptyContent>
-        {otherLocales.length > 0 && (
-          <div>
-            <p>{switcherLabel}</p>
-            {otherLocales.map((l) => (
-              <Link key={l} href={`/${l}/about`}>
-                {LOCALE_NAMES[l] ?? l}
-              </Link>
-            ))}
-          </div>
-        )}
         <Link href={`/${locale}`}>{back}</Link>
       </EmptyContent>
     </Empty>

--- a/src/app/[lang]/notes/[slug]/__tests__/not-found.test.tsx
+++ b/src/app/[lang]/notes/[slug]/__tests__/not-found.test.tsx
@@ -1,17 +1,6 @@
-import { render, screen } from "@testing-library/react";
-import React from "react";
-
-// Mock next/headers before importing the component
-jest.mock("next/headers", () => ({
-  headers: jest.fn(),
-}));
-
-jest.mock("../../../../../lib/locale-from-headers", () => ({
-  getLocaleFromHeaders: jest.fn(),
-}));
-
-jest.mock("../../../../../lib/data/locales", () => ({
-  getAvailableLocales: jest.fn(),
+jest.mock("next/navigation", () => ({
+  ...jest.requireActual("next/navigation"),
+  useParams: jest.fn(),
 }));
 
 jest.mock("../../../../../components/ui/empty", () => ({
@@ -29,143 +18,62 @@ jest.mock("../../../../../components/ui/empty", () => ({
   ),
 }));
 
-import { getLocaleFromHeaders } from "../../../../../lib/locale-from-headers";
-import { getAvailableLocales } from "../../../../../lib/data/locales";
-import { headers } from "next/headers";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { useParams } from "next/navigation";
+import NotFound from "../not-found";
 
-const mockGetLocaleFromHeaders = getLocaleFromHeaders as jest.Mock;
-const mockGetAvailableLocales = getAvailableLocales as jest.Mock;
-const mockHeaders = headers as jest.Mock;
-
-function makeHeadersObj(pathname: string) {
-  return {
-    get: jest.fn((key: string) => (key === "x-pathname" ? pathname : null)),
-  };
-}
+const mockUseParams = useParams as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-  mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-  mockGetAvailableLocales.mockResolvedValue(["zh-TW", "en", "ja"]);
+  mockUseParams.mockReturnValue({ lang: "zh-TW", slug: "my-note" });
 });
 
-async function renderNotFound() {
-  // Use require to get current module state (mocks are applied at module level)
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const NotFound = require("../not-found").default;
-  const result = await NotFound();
-  render(result as React.ReactElement);
-}
-
 describe("NotFound (notes/[slug])", () => {
-  it("renders locale-specific title for zh-TW", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-    await renderNotFound();
+  it("renders locale-specific title for zh-TW", () => {
+    mockUseParams.mockReturnValue({ lang: "zh-TW", slug: "my-note" });
+    render(<NotFound />);
     expect(screen.getByTestId("empty-title")).toHaveTextContent(
       "找不到這篇筆記"
     );
   });
 
-  it("renders locale-specific title for en", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("en");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/en/notes/my-note"));
-    await renderNotFound();
+  it("renders locale-specific title for en", () => {
+    mockUseParams.mockReturnValue({ lang: "en", slug: "my-note" });
+    render(<NotFound />);
     expect(screen.getByTestId("empty-title")).toHaveTextContent(
       "Note not found"
     );
   });
 
-  it("renders locale-specific title for ja", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("ja");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/ja/notes/my-note"));
-    await renderNotFound();
+  it("renders locale-specific title for ja", () => {
+    mockUseParams.mockReturnValue({ lang: "ja", slug: "my-note" });
+    render(<NotFound />);
     expect(screen.getByTestId("empty-title")).toHaveTextContent(
       "このノートは見つかりません"
     );
   });
 
-  it("shows locale switcher buttons only for other locales (not current)", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-    mockGetAvailableLocales.mockResolvedValue(["zh-TW", "en", "ja"]);
-    await renderNotFound();
-
-    expect(screen.getByRole("link", { name: "English" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "日本語" })).toBeInTheDocument();
-  });
-
-  it("does NOT show a locale switcher button for the current locale", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-    mockGetAvailableLocales.mockResolvedValue(["zh-TW", "en", "ja"]);
-    await renderNotFound();
-
-    const links = screen.getAllByRole("link");
-    const hrefs = links.map((l) => l.getAttribute("href"));
-    // No switcher link should point to /zh-TW/notes/my-note
-    expect(hrefs).not.toContain("/zh-TW/notes/my-note");
-  });
-
-  it("renders a 'return to notes list' link with correct href", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-    await renderNotFound();
-
+  it("renders a 'return to notes list' link with correct href for zh-TW", () => {
+    mockUseParams.mockReturnValue({ lang: "zh-TW", slug: "my-note" });
+    render(<NotFound />);
     const backLink = screen.getByRole("link", { name: /返回筆記列表/i });
-    expect(backLink).toBeInTheDocument();
     expect(backLink).toHaveAttribute("href", "/zh-TW/notes");
   });
 
-  it("shows human-readable locale names in switcher buttons, not raw codes", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-    mockGetAvailableLocales.mockResolvedValue(["zh-TW", "en", "ja"]);
-    await renderNotFound();
-
-    expect(screen.getByRole("link", { name: "English" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "日本語" })).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "en" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "ja" })).not.toBeInTheDocument();
+  it("renders a 'return to notes list' link with correct href for en", () => {
+    mockUseParams.mockReturnValue({ lang: "en", slug: "my-note" });
+    render(<NotFound />);
+    const backLink = screen.getByRole("link", { name: /back to notes/i });
+    expect(backLink).toHaveAttribute("href", "/en/notes");
   });
 
-  it("shows zh-TW display name '繁體中文' when zh-TW is an alternate locale", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("en");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/en/notes/my-note"));
-    mockGetAvailableLocales.mockResolvedValue(["zh-TW", "en"]);
-    await renderNotFound();
-
-    expect(screen.getByRole("link", { name: "繁體中文" })).toBeInTheDocument();
-  });
-
-  it("shows switcherLabel when other locales are available", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("en");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/en/notes/my-note"));
-    mockGetAvailableLocales.mockResolvedValue(["en", "zh-TW"]);
-    await renderNotFound();
-
-    expect(
-      screen.getByText("This content is also available in:")
-    ).toBeInTheDocument();
-  });
-
-  it("does NOT show switcherLabel when no other locales are available", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-    mockGetAvailableLocales.mockResolvedValue(["zh-TW"]);
-    await renderNotFound();
-
-    expect(
-      screen.queryByText("此內容也提供以下語言版本：")
-    ).not.toBeInTheDocument();
-  });
-
-  it("renders without crashing when getAvailableLocales throws", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue(makeHeadersObj("/zh-TW/notes/my-note"));
-    mockGetAvailableLocales.mockRejectedValue(new Error("fetch failed"));
-    await expect(renderNotFound()).resolves.not.toThrow();
-    expect(screen.getByTestId("empty-title")).toBeInTheDocument();
+  it("falls back to zh-TW when lang param is missing", () => {
+    mockUseParams.mockReturnValue({});
+    render(<NotFound />);
+    expect(screen.getByTestId("empty-title")).toHaveTextContent(
+      "找不到這篇筆記"
+    );
   });
 });

--- a/src/app/[lang]/notes/[slug]/not-found.tsx
+++ b/src/app/[lang]/notes/[slug]/not-found.tsx
@@ -1,60 +1,24 @@
-import { headers } from "next/headers";
+"use client";
+
 import Link from "next/link";
+import { useParams } from "next/navigation";
 import {
   Empty,
   EmptyHeader,
   EmptyTitle,
   EmptyContent,
 } from "@/components/ui/empty";
-import { getLocaleFromHeaders } from "@/lib/locale-from-headers";
-import { getAvailableLocales } from "@/lib/data/locales";
 
-const LOCALE_NAMES: Record<string, string> = {
-  "zh-TW": "繁體中文",
-  en: "English",
-  ja: "日本語",
+const labels: Record<string, { title: string; back: string }> = {
+  "zh-TW": { title: "找不到這篇筆記", back: "返回筆記列表" },
+  en: { title: "Note not found", back: "Back to Notes" },
+  ja: { title: "このノートは見つかりません", back: "ノート一覧に戻る" },
 };
 
-const labels: Record<
-  string,
-  { title: string; back: string; switcherLabel: string }
-> = {
-  "zh-TW": {
-    title: "找不到這篇筆記",
-    back: "返回筆記列表",
-    switcherLabel: "此內容也提供以下語言版本：",
-  },
-  en: {
-    title: "Note not found",
-    back: "Back to Notes",
-    switcherLabel: "This content is also available in:",
-  },
-  ja: {
-    title: "このノートは見つかりません",
-    back: "ノート一覧に戻る",
-    switcherLabel: "のコンテンツは以下の言語でもご覧いただけます：",
-  },
-};
-
-async function getSlugFromHeaders(): Promise<string> {
-  const headersList = await headers();
-  const pathname = headersList.get("x-pathname") ?? "/";
-  return pathname.split("/")[3] ?? "";
-}
-
-export default async function NotFound() {
-  const locale = await getLocaleFromHeaders();
-  const slug = await getSlugFromHeaders();
-
-  let availableLocales: string[] = [];
-  try {
-    availableLocales = await getAvailableLocales(slug, "notes");
-  } catch {
-    availableLocales = [];
-  }
-
-  const otherLocales = availableLocales.filter((l) => l !== locale);
-  const { title, back, switcherLabel } = labels[locale] ?? labels["zh-TW"];
+export default function NotFound() {
+  const params = useParams();
+  const locale = (params?.lang as string) ?? "zh-TW";
+  const { title, back } = labels[locale] ?? labels["zh-TW"];
 
   return (
     <Empty>
@@ -62,16 +26,6 @@ export default async function NotFound() {
         <EmptyTitle>{title}</EmptyTitle>
       </EmptyHeader>
       <EmptyContent>
-        {otherLocales.length > 0 && (
-          <div>
-            <p>{switcherLabel}</p>
-            {otherLocales.map((l) => (
-              <Link key={l} href={`/${l}/notes/${slug}`}>
-                {LOCALE_NAMES[l] ?? l}
-              </Link>
-            ))}
-          </div>
-        )}
         <Link href={`/${locale}/notes`}>{back}</Link>
       </EmptyContent>
     </Empty>

--- a/src/app/[lang]/projects/[slug]/__tests__/not-found.test.tsx
+++ b/src/app/[lang]/projects/[slug]/__tests__/not-found.test.tsx
@@ -1,12 +1,6 @@
-import { render, screen } from "@testing-library/react";
-import NotFound from "../not-found";
-
-jest.mock("../../../../../lib/locale-from-headers", () => ({
-  getLocaleFromHeaders: jest.fn(),
-}));
-
-jest.mock("../../../../../lib/data/locales", () => ({
-  getAvailableLocales: jest.fn(),
+jest.mock("next/navigation", () => ({
+  ...jest.requireActual("next/navigation"),
+  useParams: jest.fn(),
 }));
 
 jest.mock("../../../../../components/ui/empty", () => ({
@@ -22,15 +16,6 @@ jest.mock("../../../../../components/ui/empty", () => ({
   EmptyContent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="empty-content">{children}</div>
   ),
-  EmptyDescription: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="empty-description">{children}</div>
-  ),
-}));
-
-jest.mock("next/headers", () => ({
-  headers: jest.fn().mockResolvedValue({
-    get: jest.fn().mockReturnValue("/en/projects/my-slug"),
-  }),
 }));
 
 jest.mock("next/link", () => ({
@@ -44,155 +29,62 @@ jest.mock("next/link", () => ({
   }) => <a href={href}>{children}</a>,
 }));
 
-import { getLocaleFromHeaders } from "../../../../../lib/locale-from-headers";
-import { getAvailableLocales } from "../../../../../lib/data/locales";
-import { headers } from "next/headers";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { useParams } from "next/navigation";
+import NotFound from "../not-found";
 
-const mockGetLocaleFromHeaders = getLocaleFromHeaders as jest.Mock;
-const mockGetAvailableLocales = getAvailableLocales as jest.Mock;
-const mockHeaders = headers as jest.Mock;
+const mockUseParams = useParams as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Default: English locale, slug = "my-slug"
-  mockGetLocaleFromHeaders.mockResolvedValue("en");
-  mockHeaders.mockResolvedValue({
-    get: jest.fn().mockReturnValue("/en/projects/my-slug"),
-  });
+  mockUseParams.mockReturnValue({ lang: "en", slug: "my-slug" });
 });
 
 describe("projects/[slug]/not-found", () => {
-  it("renders locale-specific title for 'en'", async () => {
-    mockGetAvailableLocales.mockResolvedValue(["en", "zh-TW"]);
-
-    render(await NotFound());
-
+  it("renders locale-specific title for 'en'", () => {
+    mockUseParams.mockReturnValue({ lang: "en", slug: "my-slug" });
+    render(<NotFound />);
     expect(screen.getByTestId("empty-title")).toHaveTextContent(
       "Project not found"
     );
   });
 
-  it("renders locale-specific title for 'zh-TW'", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("zh-TW");
-    mockHeaders.mockResolvedValue({
-      get: jest.fn().mockReturnValue("/zh-TW/projects/my-slug"),
-    });
-    mockGetAvailableLocales.mockResolvedValue(["zh-TW", "en"]);
-
-    render(await NotFound());
-
+  it("renders locale-specific title for 'zh-TW'", () => {
+    mockUseParams.mockReturnValue({ lang: "zh-TW", slug: "my-slug" });
+    render(<NotFound />);
     expect(screen.getByTestId("empty-title")).toHaveTextContent(
       "找不到這個專案"
     );
   });
 
-  it("renders locale-specific title for 'ja'", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("ja");
-    mockHeaders.mockResolvedValue({
-      get: jest.fn().mockReturnValue("/ja/projects/my-slug"),
-    });
-    mockGetAvailableLocales.mockResolvedValue(["ja"]);
-
-    render(await NotFound());
-
+  it("renders locale-specific title for 'ja'", () => {
+    mockUseParams.mockReturnValue({ lang: "ja", slug: "my-slug" });
+    render(<NotFound />);
     expect(screen.getByTestId("empty-title")).toHaveTextContent(
       "このプロジェクトは見つかりません"
     );
   });
 
-  it("shows buttons only for other available locales, not the current one", async () => {
-    mockGetAvailableLocales.mockResolvedValue(["en", "zh-TW", "ja"]);
-
-    render(await NotFound());
-
-    // "en" is current locale, should NOT appear as a locale switcher link
-    const links = screen.getAllByRole("link");
-    const localeSwitcherLinks = links.filter(
-      (link) =>
-        link.getAttribute("href")?.includes("/en/projects/my-slug") &&
-        !link.getAttribute("href")?.endsWith("/projects")
-    );
-    expect(localeSwitcherLinks).toHaveLength(0);
-
-    // zh-TW and ja should appear (as human-readable names)
-    expect(screen.getByRole("link", { name: "繁體中文" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "日本語" })).toBeInTheDocument();
-  });
-
-  it("does NOT show a button for the current locale", async () => {
-    mockGetAvailableLocales.mockResolvedValue(["en", "zh-TW"]);
-
-    render(await NotFound());
-
-    const localeSwitcherLinks = screen
-      .getAllByRole("link")
-      .filter((link) => link.getAttribute("href") === "/en/projects/my-slug");
-    expect(localeSwitcherLinks).toHaveLength(0);
-  });
-
-  it("renders 'return to projects' link with correct href", async () => {
-    mockGetAvailableLocales.mockResolvedValue(["en"]);
-
-    render(await NotFound());
-
+  it("renders 'return to projects' link with correct href for en", () => {
+    mockUseParams.mockReturnValue({ lang: "en", slug: "my-slug" });
+    render(<NotFound />);
     const backLink = screen.getByRole("link", { name: /back to projects/i });
     expect(backLink).toHaveAttribute("href", "/en/projects");
   });
 
-  it("shows human-readable locale names, not raw locale codes", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("en");
-    mockHeaders.mockResolvedValue({
-      get: jest.fn().mockReturnValue("/en/projects/my-slug"),
-    });
-    mockGetAvailableLocales.mockResolvedValue(["en", "zh-TW", "ja"]);
-
-    render(await NotFound());
-
-    expect(screen.getByRole("link", { name: "繁體中文" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "日本語" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "zh-TW" })
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "ja" })).not.toBeInTheDocument();
+  it("renders 'return to projects' link with correct href for zh-TW", () => {
+    mockUseParams.mockReturnValue({ lang: "zh-TW", slug: "my-slug" });
+    render(<NotFound />);
+    const backLink = screen.getByRole("link", { name: /返回專案列表/i });
+    expect(backLink).toHaveAttribute("href", "/zh-TW/projects");
   });
 
-  it("shows switcherLabel when other locales are available", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("en");
-    mockHeaders.mockResolvedValue({
-      get: jest.fn().mockReturnValue("/en/projects/my-slug"),
-    });
-    mockGetAvailableLocales.mockResolvedValue(["en", "zh-TW"]);
-
-    render(await NotFound());
-
-    expect(
-      screen.getByText("This content is also available in:")
-    ).toBeInTheDocument();
-  });
-
-  it("does NOT show switcherLabel when no other locales are available", async () => {
-    mockGetLocaleFromHeaders.mockResolvedValue("en");
-    mockHeaders.mockResolvedValue({
-      get: jest.fn().mockReturnValue("/en/projects/my-slug"),
-    });
-    mockGetAvailableLocales.mockResolvedValue(["en"]);
-
-    render(await NotFound());
-
-    expect(
-      screen.queryByText("This content is also available in:")
-    ).not.toBeInTheDocument();
-  });
-
-  it("still renders without crashing when getAvailableLocales throws", async () => {
-    mockGetAvailableLocales.mockRejectedValue(new Error("Sanity error"));
-
-    // Should not throw
-    expect(async () => render(await NotFound())).not.toThrow();
-
-    render(await NotFound());
-    expect(screen.getAllByTestId("empty-title")[0]).toHaveTextContent(
-      "Project not found"
+  it("falls back to zh-TW when lang param is missing", () => {
+    mockUseParams.mockReturnValue({});
+    render(<NotFound />);
+    expect(screen.getByTestId("empty-title")).toHaveTextContent(
+      "找不到這個專案"
     );
   });
 });

--- a/src/app/[lang]/projects/[slug]/not-found.tsx
+++ b/src/app/[lang]/projects/[slug]/not-found.tsx
@@ -1,7 +1,7 @@
+"use client";
+
 import Link from "next/link";
-import { headers } from "next/headers";
-import { getLocaleFromHeaders } from "@/lib/locale-from-headers";
-import { getAvailableLocales } from "@/lib/data/locales";
+import { useParams } from "next/navigation";
 import {
   Empty,
   EmptyHeader,
@@ -9,53 +9,19 @@ import {
   EmptyContent,
 } from "@/components/ui/empty";
 
-const LOCALE_NAMES: Record<string, string> = {
-  "zh-TW": "繁體中文",
-  en: "English",
-  ja: "日本語",
-};
-
-const labels: Record<
-  string,
-  { title: string; back: string; switcherLabel: string }
-> = {
-  "zh-TW": {
-    title: "找不到這個專案",
-    back: "返回專案列表",
-    switcherLabel: "此內容也提供以下語言版本：",
-  },
-  en: {
-    title: "Project not found",
-    back: "Back to Projects",
-    switcherLabel: "This content is also available in:",
-  },
+const labels: Record<string, { title: string; back: string }> = {
+  "zh-TW": { title: "找不到這個專案", back: "返回專案列表" },
+  en: { title: "Project not found", back: "Back to Projects" },
   ja: {
     title: "このプロジェクトは見つかりません",
     back: "プロジェクト一覧に戻る",
-    switcherLabel: "このコンテンツは以下の言語でもご覧いただけます：",
   },
 };
 
-function getLabel(locale: string) {
-  return labels[locale] ?? labels["zh-TW"];
-}
-
-export default async function NotFound() {
-  const locale = await getLocaleFromHeaders();
-
-  const headersList = await headers();
-  const pathname = headersList.get("x-pathname") ?? "/";
-  const slug = pathname.split("/")[3] ?? "";
-
-  let availableLocales: string[] = [];
-  try {
-    availableLocales = await getAvailableLocales(slug, "projects");
-  } catch {
-    availableLocales = [];
-  }
-
-  const otherLocales = availableLocales.filter((l) => l !== locale);
-  const { title, back, switcherLabel } = getLabel(locale);
+export default function NotFound() {
+  const params = useParams();
+  const locale = (params?.lang as string) ?? "zh-TW";
+  const { title, back } = labels[locale] ?? labels["zh-TW"];
 
   return (
     <Empty>
@@ -63,16 +29,6 @@ export default async function NotFound() {
         <EmptyTitle>{title}</EmptyTitle>
       </EmptyHeader>
       <EmptyContent>
-        {otherLocales.length > 0 && (
-          <div>
-            <p>{switcherLabel}</p>
-            {otherLocales.map((l) => (
-              <Link key={l} href={`/${l}/projects/${slug}`}>
-                {LOCALE_NAMES[l] ?? l}
-              </Link>
-            ))}
-          </div>
-        )}
         <Link href={`/${locale}/projects`}>{back}</Link>
       </EmptyContent>
     </Empty>

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,7 +1,3 @@
-jest.mock("../../lib/locale-from-headers", () => ({
-  getLocaleFromHeaders: jest.fn(),
-}));
-
 jest.mock("next/font/google", () => ({
   Inter: () => ({ variable: "--font-inter", subsets: ["latin"] }),
   Ubuntu_Mono: () => ({
@@ -11,31 +7,23 @@ jest.mock("next/font/google", () => ({
   }),
 }));
 
+jest.mock("@vercel/analytics/next", () => ({
+  Analytics: () => null,
+}));
+
 import React from "react";
 import { render } from "@testing-library/react";
 import RootLayout from "../layout";
-import { getLocaleFromHeaders } from "../../lib/locale-from-headers";
-
-const mockGetLocale = getLocaleFromHeaders as jest.Mock;
-
-beforeEach(() => {
-  jest.clearAllMocks();
-});
 
 describe("RootLayout", () => {
-  it("calls getLocaleFromHeaders() to determine lang", async () => {
-    mockGetLocale.mockResolvedValue("en");
-
-    render(await RootLayout({ children: <div>content</div> }));
-
-    expect(mockGetLocale).toHaveBeenCalled();
+  it("renders children", () => {
+    const { getByText } = render(RootLayout({ children: <div>content</div> }));
+    expect(getByText("content")).toBeInTheDocument();
   });
 
-  it("uses locale returned by getLocaleFromHeaders() for html lang attribute", async () => {
-    mockGetLocale.mockResolvedValue("ja");
-
-    const element = await RootLayout({ children: <div>content</div> });
-
-    expect(element.props.lang).toBe("ja");
+  it("applies font class variables to html element", () => {
+    const element = RootLayout({ children: <div /> });
+    expect(element.props.className).toContain("--font-ubuntu-mono");
+    expect(element.props.className).toContain("--font-inter");
   });
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import { getLocaleFromHeaders } from "@/lib/locale-from-headers";
 import { Analytics } from "@vercel/analytics/next";
 import { Inter, Ubuntu_Mono } from "next/font/google";
 import type { ReactNode } from "react";
@@ -11,16 +10,9 @@ const ubuntuMono = Ubuntu_Mono({
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
-export default async function RootLayout({
-  children,
-}: {
-  children: ReactNode;
-}) {
-  const lang = await getLocaleFromHeaders();
-
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
-      lang={lang}
       suppressHydrationWarning
       className={`${ubuntuMono.variable} ${inter.variable}`}
     >


### PR DESCRIPTION
## Problem

Two cascading errors blocked production builds:

```
[Error: DYNAMIC_SERVER_USAGE] { digest: 'DYNAMIC_SERVER_USAGE' }

Error: Page changed from static to dynamic at runtime /zh-TW/about, reason: headers
```

Both stem from calling `headers()` (a dynamic API) inside routes that use `generateStaticParams()` (static rendering). Next.js 16 enforces a hard boundary between the two.

---

## Root Cause

<table>
<tr><th>Location</th><th>Calls <code>headers()</code>?</th><th>Has <code>generateStaticParams</code>?</th><th>Conflict</th></tr>
<tr><td><code>app/layout.tsx</code></td><td>✅ Yes (via <code>getLocaleFromHeaders</code>)</td><td>Wraps all static routes</td><td>⛔ Yes</td></tr>
<tr><td><code>[lang]/about/not-found.tsx</code></td><td>✅ Yes</td><td>Parent page has it</td><td>⛔ Yes</td></tr>
<tr><td><code>[lang]/notes/[slug]/not-found.tsx</code></td><td>✅ Yes</td><td>Parent page has it</td><td>⛔ Yes</td></tr>
<tr><td><code>[lang]/projects/[slug]/not-found.tsx</code></td><td>✅ Yes</td><td>Parent page has it</td><td>⛔ Yes</td></tr>
</table>

The `not-found.tsx` conflict is triggered at runtime when `notFound()` is called (e.g. Sanity content missing for a locale), rendering a page that calls `headers()` within a statically pre-rendered route.

---

## Fix

### 1 — Root layout (`fix(layout)`)

`LangSetter` in `[lang]/layout.tsx` already updates `document.documentElement.lang` client-side via `useEffect`. The `headers()` call in the root layout was redundant.

```diff
- import { getLocaleFromHeaders } from "@/lib/locale-from-headers";
- export default async function RootLayout(...) {
-   const lang = await getLocaleFromHeaders();
-   return <html lang={lang} ...>
+ export default function RootLayout(...) {
+   return <html ...>
```

### 2 — Not-found pages (`fix(not-found)`)

Converted all three `not-found.tsx` files from async Server Components (using `headers()`) to Client Components (using `useParams()`). The `[lang]` segment is already in the URL, so `useParams()` gives the locale without any dynamic API.

```diff
+ "use client";
+ import { useParams } from "next/navigation";

  export default function NotFound() {
-   const locale = await getLocaleFromHeaders();   // headers() ❌
+   const params = useParams();
+   const locale = (params?.lang as string) ?? "zh-TW";
```

**Trade-off:** The locale switcher ("also available in...") was removed from not-found pages — it required `getAvailableLocales()` which is an async server fetch incompatible with Client Components. This is a minor UX degradation on error pages.

---

## Tests

All tests updated to mock `useParams` instead of `headers` / `getLocaleFromHeaders`:

| Suite | Before | After |
|---|---|---|
| `layout.test.tsx` | mocked `getLocaleFromHeaders` | tests `children` render + font class |
| `about/not-found.test.tsx` | async Server Component render | sync Client Component + `useParams` mock |
| `notes/not-found.test.tsx` | async Server Component render | sync Client Component + `useParams` mock |
| `projects/not-found.test.tsx` | async Server Component render | sync Client Component + `useParams` mock |

```
Test Suites: 4 passed
Tests:       20 passed
TypeScript:  No errors
```

---

## 摘要（zh-TW）

修正在使用 `generateStaticParams()` 的靜態路由中呼叫 `headers()` 所導致的 `DYNAMIC_SERVER_USAGE` 錯誤。

- **根 layout**：移除多餘的 `getLocaleFromHeaders()`，改由既有的 `LangSetter` client component 負責設定 `html[lang]`。
- **Not-found 頁面**：三個 `not-found.tsx` 改為 client component，透過 `useParams()` 從 URL 讀取 locale，不再使用動態 API。
- 移除 not-found 頁面的語言切換器（次要功能，原為 async server fetch，與 client component 不相容）。
- 所有相關測試已同步更新，全數通過。
