### PR TITLE
fix(seo): add explicit openGraph fields to notes and projects slug pages

### DIFF
--- a/src/app/(site)/[lang]/notes/[slug]/page.tsx
+++ b/src/app/(site)/[lang]/notes/[slug]/page.tsx
@@ -80,5 +80,11 @@ export async function generateMetadata({
       canonical: `/${lang}/notes/${slug}`,
       languages,
     },
+    openGraph: {
+      title: note.title,
+      description: note.description,
+      type: "article",
+      publishedTime: note.date,
+    },
   };
 }

--- a/src/app/(site)/[lang]/projects/[slug]/page.tsx
+++ b/src/app/(site)/[lang]/projects/[slug]/page.tsx
@@ -80,6 +80,8 @@ export async function generateMetadata({
       languages,
     },
     openGraph: {
+      title: project.title,
+      description: project.description,
       type: "article",
       publishedTime: project.date,
     },


### PR DESCRIPTION
## What & Why

Follow-up to #23. The post-review cleanup in that PR incorrectly assumed Next.js would propagate page-level `title`/`description` to `og:title`/`og:description` automatically. It does not — when a parent layout already defines a complete `openGraph` block, child segments must explicitly override the fields they need; otherwise the layout's values are inherited unchanged.

**Observed on production after #23 merged:**
- `og:title` → "Andrew Tseng - Software Engineer" (layout default, not article title)
- `og:description` → site description (not article description)
- `og:url` → `https://andrewck24.vercel.app` (root, not article URL)
- `og:type` → `website` (should be `article`)

## Changes

| File | Change |
|------|--------|
| `notes/[slug]/page.tsx` | Add `openGraph` block (title, description, type: "article", publishedTime) — was missing entirely |
| `projects/[slug]/page.tsx` | Restore `openGraph.title` and `openGraph.description` removed in #23 |

## Test Plan

- [x] 275 unit tests pass
- [x] TypeScript type-check passes
- [x] `og:title` on `/zh-TW/notes/<slug>` shows article title
- [x] `og:type` on note/project pages shows `article`
- [x] `og:url` on note/project pages shows the article URL

## zh-TW 摘要

修正 #23 中誤移除的 OG 欄位。Next.js 的 metadata 合併不會自動將頂層 `title` 複寫到父層 layout 設定的 `og:title`，子層必須明確設定 `openGraph` 才能覆寫。notes 頁補上完整 `openGraph` block；projects 頁恢復被誤刪的 `title` 和 `description`。