### PR TITLE
fix(seo): complete openGraph and twitter card metadata on slug pages

### DIFF
--- a/src/app/(site)/[lang]/notes/[slug]/page.tsx
+++ b/src/app/(site)/[lang]/notes/[slug]/page.tsx
@@ -83,8 +83,17 @@ export async function generateMetadata({
     openGraph: {
       title: note.title,
       description: note.description,
+      url: `/${lang}/notes/${slug}`,
+      siteName: "Andrew Tseng - Software Engineer",
+      locale: lang === "zh-TW" ? "zh_TW" : lang === "ja" ? "ja_JP" : "en_US",
       type: "article",
       publishedTime: note.date,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: note.title,
+      description: note.description,
+      creator: "@andrewck24",
     },
   };
 }

--- a/src/app/(site)/[lang]/projects/[slug]/page.tsx
+++ b/src/app/(site)/[lang]/projects/[slug]/page.tsx
@@ -82,8 +82,17 @@ export async function generateMetadata({
     openGraph: {
       title: project.title,
       description: project.description,
+      url: `/${lang}/projects/${slug}`,
+      siteName: "Andrew Tseng - Software Engineer",
+      locale: lang === "zh-TW" ? "zh_TW" : lang === "ja" ? "ja_JP" : "en_US",
       type: "article",
       publishedTime: project.date,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: project.title,
+      description: project.description,
+      creator: "@andrewck24",
     },
   };
 }


### PR DESCRIPTION
## What & Why

Follow-up to #24. Setting `openGraph` in a child segment replaces the parent layout's entire `openGraph` block — Next.js does not deep-merge. After #24, the slug pages were missing `og:url`, `og:locale`, `og:siteName`, and all `twitter:*` fields were still inheriting the site-level defaults.

## Changes

Both `notes/[slug]/page.tsx` and `projects/[slug]/page.tsx`:

| Field | Before | After |
|-------|--------|-------|
| `og:url` | absent | article URL |
| `og:site_name` | absent | "Andrew Tseng - Software Engineer" |
| `og:locale` | absent | matches page locale (`zh_TW` / `en_US` / `ja_JP`) |
| `twitter:title` | site default | article title |
| `twitter:description` | site description | article description |
| `twitter:image` | profile avatar (explicit) | absent → falls back to `og:image` (article OG image) |

## Test Plan

- [x] 275 unit tests pass
- [x] TypeScript type-check passes
- [x] Verify on preview: `og:url`, `og:site_name`, `og:locale` present and correct
- [x] Verify on preview: `twitter:title` / `twitter:description` match article content
- [x] Verify on preview: `twitter:image` absent (fallback to article `og:image`)

## zh-TW 摘要

修正 #24 引入的 OG/Twitter Card 不完整問題。Next.js metadata 合併中，子層的 `openGraph` 會整體取代父層，非深合併，因此必須在子層明確補齊所有需要的欄位。兩個 slug 頁面補上 `url`、`siteName`、`locale`；twitter card 欄位改為文章標題與描述，移除 `images` 讓 Twitter 自動 fallback 至文章專屬 OG 圖。