### PR TITLE
fix(seo): add homepage opengraph-image and remove broken avatar reference

### DIFF
--- a/src/app/(site)/[lang]/layout.tsx
+++ b/src/app/(site)/[lang]/layout.tsx
@@ -60,21 +60,12 @@ export async function generateMetadata({
       description,
       siteName: title,
       url: "https://andrewck24.vercel.app",
-      images: [
-        {
-          url: "/images/profile/avatar.jpg",
-          width: 1200,
-          height: 630,
-          alt: title,
-        },
-      ],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
       creator: "@andrewck24",
-      images: ["/images/profile/avatar.jpg"],
     },
     robots: {
       index: true,

--- a/src/app/(site)/[lang]/opengraph-image.tsx
+++ b/src/app/(site)/[lang]/opengraph-image.tsx
@@ -1,0 +1,68 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const runtime = "nodejs";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+
+  const subtitles: Record<string, string> = {
+    "zh-TW": "軟體工程師",
+    en: "Software Engineer",
+    ja: "ソフトウェアエンジニア",
+  };
+
+  const subtitle = subtitles[lang] ?? subtitles["en"];
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background:
+          "linear-gradient(135deg, #0f172a 0%, #1e293b 60%, #0f172a 100%)",
+        color: "white",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 80,
+          fontWeight: "bold",
+          letterSpacing: "-2px",
+        }}
+      >
+        Andrew Tseng
+      </div>
+      <div
+        style={{
+          fontSize: 36,
+          marginTop: 24,
+          color: "#94a3b8",
+          letterSpacing: "2px",
+          textTransform: "uppercase",
+        }}
+      >
+        {subtitle}
+      </div>
+      <div
+        style={{
+          marginTop: 48,
+          width: 60,
+          height: 4,
+          background: "linear-gradient(90deg, #667eea, #764ba2)",
+          borderRadius: 2,
+        }}
+      />
+    </div>,
+    { ...size }
+  );
+}


### PR DESCRIPTION
## What & Why

`layout.tsx` referenced `/images/profile/avatar.jpg` as the fallback `og:image` for all pages, but this file does not exist in the repo. All pages without their own `opengraph-image.tsx` (homepage, listing pages, about) were serving a broken `og:image`.

## Changes

| File | Change |
|------|--------|
| `[lang]/opengraph-image.tsx` | New file — generates a 1200×630 branded image via `ImageResponse` with locale-aware subtitle (`軟體工程師` / `Software Engineer` / `ソフトウェアエンジニア`) |
| `[lang]/layout.tsx` | Remove `openGraph.images` and `twitter.images` hardcoded to the non-existent avatar path; file-based convention now handles og:image for pages without their own handler |

**Coverage after this change:**

| Page | og:image source |
|------|----------------|
| Homepage / listing pages / about | `[lang]/opengraph-image.tsx` (generated) |
| Note slug pages | `notes/[slug]/opengraph-image.tsx` (Sanity coverImage → generated fallback) |
| Project slug pages | `projects/[slug]/opengraph-image.tsx` (Sanity coverImage → generated fallback) |

## Test Plan

- [x] 275 unit tests pass
- [x] TypeScript type-check passes
- [x] Verify on preview: `og:image` on `/zh-TW` resolves to generated image (not broken URL)
- [x] Verify on preview: `og:image` on `/zh-TW/notes` and `/zh-TW/projects` resolves to generated image
- [x] Visual check: open the opengraph-image URL directly to confirm layout

## zh-TW 摘要

修正所有非 slug 頁面（首頁、列表頁、about）的 `og:image` 指向不存在的 `avatar.jpg` 問題。在 `[lang]/` segment 加入 `opengraph-image.tsx`，以 `ImageResponse` 生成含 locale-aware 副標題的品牌圖片，並移除 layout 裡硬編碼的 `images` 陣列。